### PR TITLE
Add `createMap` option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 sandbox.js
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -13,7 +13,10 @@ const Xache = require('xache')
 
 const cache = new Xache({
   maxSize: 10, // at max (ish) have 10 entries
-  maxAge: 100 // auto expire entries after (ish) 100ms
+  maxAge: 100, // auto expire entries after (ish) 100ms
+  createMap () { // optional function to create backing storage
+    return new Map()
+  }
 })
 
 // When maxSize is hit, the oldest entries are removed

--- a/index.js
+++ b/index.js
@@ -1,10 +1,11 @@
 module.exports = class MaxCache {
-  constructor ({ maxSize, maxAge }) {
+  constructor ({ maxSize, maxAge, createMap }) {
     this.maxSize = maxSize
     this.maxAge = maxAge
 
-    this._latest = new Map()
-    this._oldest = new Map()
+    this._createMap = createMap || defaultCreateMap
+    this._latest = this._createMap()
+    this._oldest = this._createMap()
     this._gced = false
     this._interval = null
 
@@ -74,7 +75,7 @@ module.exports = class MaxCache {
   _gc () {
     this._gced = true
     this._oldest = this._latest
-    this._latest = new Map()
+    this._latest = this._createMap()
   }
 }
 
@@ -96,4 +97,8 @@ class Iterator {
     }
     return this.b.next()
   }
+}
+
+function defaultCreateMap () {
+  return new Map()
 }


### PR DESCRIPTION
This PR adds a new option, `createMap`, for cases where different backing storage for the cache is desired, such as https://github.com/mafintosh/turbo-hash-map when cache keys are buffers.